### PR TITLE
Perform fft-shift in sparsdr compressor

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ Usage: sparsdr_filter <fft_size> <start_bin> <stop_bin> <input_file> <output_fil
 
 The executable will channelize the input file, pick out the relevant bins, and then reconstruct the lower rate I/Q samples.
 
-> **NOTE:**  `sparsdr_filter` currently only supports bin ranges that are on one side of the fft window. That is, the seelcted window should exclusively have only positive or negative frequencies.
+> **NOTE:**  `sparsdr_filter` uses positive bin indices only. Bin index 0 corresponds to the lowest (most negative) frequency in the complex baseband sense. Bin index `fft_size - 1` corresponds to the highest (most positive) frequency.
 
 **Example**: To get the 2402 MHz BLE channel from a 100 MHz capture of the ISM band centered at 2450 MHz, the following command can be used:
 
 ```bash
-sparsdr_filter 1000 510 530 <input_file> <output_file>
+sparsdr_filter 1000 10 30 <input_file> <output_file>
 ```
 
 The output file should be interpreted at a sample rate of 2 MHz.

--- a/src/main_filter.cpp
+++ b/src/main_filter.cpp
@@ -10,7 +10,7 @@ void compress_wrapper(unsigned int fft_size, unsigned int start_bin, unsigned in
 void reconstruct_wrapper(unsigned int fft_size, const char *filename)
 {
     FileInterface *interface = new FileInterface("/tmp/interimfile", filename);
-    SparSDRReconstructor sparsdr_r(fft_size, interface, true);
+    SparSDRReconstructor sparsdr_r(fft_size, interface);
     sparsdr_r.reconstruct();
 }
 

--- a/src/main_reconstruct.cpp
+++ b/src/main_reconstruct.cpp
@@ -19,7 +19,7 @@ int main(int argc, char **argv)
 
     // Process the input
     StdInterface *interface = new StdInterface();
-    SparSDRReconstructor sparsdr(fft_size, interface, false);
+    SparSDRReconstructor sparsdr(fft_size, interface);
     sparsdr.reconstruct();
 
     return 0;

--- a/src/sparsdr.h
+++ b/src/sparsdr.h
@@ -37,13 +37,12 @@ private:
 class SparSDRReconstructor
 {
 public:
-    SparSDRReconstructor(unsigned int fft_size, Interface *interface, bool fft_shift);
+    SparSDRReconstructor(unsigned int fft_size, Interface *interface);
     ~SparSDRReconstructor();
     void reconstruct();
 
 private:
     unsigned int fft_size;
-    bool fft_shift = false;
     FFTEngine *ifft0 = nullptr;
     FFTEngine *ifft1 = nullptr;
 

--- a/src/tests/identitytest.cpp
+++ b/src/tests/identitytest.cpp
@@ -32,7 +32,7 @@ void run_reconstruct()
 {
     unsigned int fft_size = 1024;
     FileInterface *interface2 = new FileInterface("./interimfile", "./testfile2");
-    SparSDRReconstructor sparsdr2(fft_size, interface2, false);
+    SparSDRReconstructor sparsdr2(fft_size, interface2);
     sparsdr2.reconstruct();
 }
 


### PR DESCRIPTION
sparsdr compressor performs fft-shift always. This allows easy and contiguous indexing before filtering. Allows the reconstruct- ion algorithm to know to always perform an fftshift before opera- ting on the data.

sparsdr_filter can now filter any contiguous band in the input. Earlier, it was able to only filter one one of the sides of the center frequency.